### PR TITLE
Fix hash parsing in ScrollToHash component

### DIFF
--- a/src/components/ScrollToHash.tsx
+++ b/src/components/ScrollToHash.tsx
@@ -11,7 +11,7 @@ export default function ScrollToHash() {
     const hash = window.location.hash;
     if (hash) {
       // Remove the '#' symbol
-      const id = hash.replace(" ", "");
+      const id = hash.replace("#", "");
       const element = document.getElementById(id);
       if (element) {
         element.scrollIntoView({ behavior: "smooth" });


### PR DESCRIPTION
## Summary
- ensure ScrollToHash removes `#` from window location hash before element lookup

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_689d8a78060c8331bc8bae11a7a275b8