### PR TITLE
Rename tableOfContent to tableOfContents

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -74,7 +74,7 @@ export default function About() {
 
   return (
     <Column maxWidth="m">
-      {about.tableOfContent.display && (
+      {about.tableOfContents.display && (
         <Column
           left="0"
           style={{ top: "50%", transform: "translateY(-50%)" }}

--- a/src/app/resources/content.js
+++ b/src/app/resources/content.js
@@ -49,7 +49,7 @@ const about = {
   label: "About",
   title: "About me",
   description: `Meet ${person.name}, ${person.role} from ${person.location}`,
-  tableOfContent: {
+  tableOfContents: {
     display: true,
     subItems: false,
   },

--- a/src/components/about/TableOfContents.tsx
+++ b/src/components/about/TableOfContents.tsx
@@ -11,7 +11,7 @@ interface TableOfContentsProps {
     items: string[];
   }[];
   about: {
-    tableOfContent: {
+    tableOfContents: {
       display: boolean;
       subItems: boolean;
     };
@@ -32,7 +32,7 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({ structure, about }) =
     }
   };
 
-  if (!about.tableOfContent.display) return null;
+  if (!about.tableOfContents.display) return null;
 
   return (
     <Column
@@ -61,7 +61,7 @@ const TableOfContents: React.FC<TableOfContentsProps> = ({ structure, about }) =
               <Flex height="1" minWidth="16" background="neutral-strong"></Flex>
               <Text>{section.title}</Text>
             </Flex>
-            {about.tableOfContent.subItems && (
+            {about.tableOfContents.subItems && (
               <>
                 {section.items.map((item, itemIndex) => (
                   <Flex


### PR DESCRIPTION
## Summary
- rename `tableOfContent` to `tableOfContents` in about content
- update TableOfContents component and about page references

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_689d8c1f6348833183f3afec50d065c9